### PR TITLE
Version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.0
+
+* EmailValidator.Validate() is now, by Dart convention, EmailValidator.validate().
+
 ## 0.1.6
 
 * Cleaned up code a bit, no API changes.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add this to your package's `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-    email_validator: '^0.1.6'
+    email_validator: '^1.0.0'
 ```
 
 #### 2. Install it

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -27,7 +27,6 @@ linter:
     # - avoid_bool_literals_in_conditional_expressions # not yet tested
     # - avoid_catches_without_on_clauses # we do this commonly
     # - avoid_catching_errors # we do this commonly
-    - avoid_classes_with_only_static_members
     # - avoid_double_and_int_checks # only useful when targeting JS runtime
     - avoid_empty_else
     - avoid_field_initializers_in_const_classes

--- a/example/example.dart
+++ b/example/example.dart
@@ -2,8 +2,8 @@ import 'dart:core';
 import 'package:email_validator/email_validator.dart';
 
 void main() {
-    const String email = "fredrik.eilertsen@gmail.com";
-    final bool isValid = EmailValidator.Validate(email);
+    const String email = 'fredrik.eilertsen@gmail.com';
+    final bool isValid = EmailValidator.validate(email);
 
     print('Email is valid? ' + (isValid ? 'yes' : 'no'));
 }

--- a/lib/email_validator.dart
+++ b/lib/email_validator.dart
@@ -259,7 +259,7 @@ class EmailValidator {
   }
 
   /// Validate the specified email address.
-  static bool Validate(String email,
+  static bool validate(String email,
       [bool allowTopLevelDomains = false, bool allowInternational = false]) {
     _index = 0;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: email_validator
-version: 0.1.6
+version: 1.0.0
 
 authors: 
   - Fredrik Eilertsen <fredrik.eilertsen@gmail.com>

--- a/test/email_validator_test.dart
+++ b/test/email_validator_test.dart
@@ -4,138 +4,138 @@ import 'package:email_validator/email_validator.dart';
 
 void main() {
   var validAddresses = [
-    "fredrik@dualog.com",
-    "\"Abc\\@def\"@example.com",
-    "\"Fred Bloggs\"@example.com",
-    "\"Joe\\\\Blow\"@example.com",
-    "\"Abc@def\"@example.com",
-    "customer/department=shipping@example.com",
-    "\$A12345@example.com",
-    "!def!xyz%abc@example.com",
-    "_somename@example.com",
-    "valid.ipv4.addr@[123.1.72.10]",
-    "valid.ipv6.addr@[IPv6:0::1]",
-    "valid.ipv6.addr@[IPv6:2607:f0d0:1002:51::4]",
-    "valid.ipv6.addr@[IPv6:fe80::230:48ff:fe33:bc33]",
-    "valid.ipv6.addr@[IPv6:fe80:0000:0000:0000:0202:b3ff:fe1e:8329]",
-    "valid.ipv6v4.addr@[IPv6:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:127.0.0.1]",
+    'fredrik@dualog.com',
+    '\"Abc\\@def\"@example.com',
+    '\"Fred Bloggs\"@example.com',
+    '\"Joe\\\\Blow\"@example.com',
+    '\"Abc@def\"@example.com',
+    'customer/department=shipping@example.com',
+    '\$A12345@example.com',
+    '!def!xyz%abc@example.com',
+    '_somename@example.com',
+    'valid.ipv4.addr@[123.1.72.10]',
+    'valid.ipv6.addr@[IPv6:0::1]',
+    'valid.ipv6.addr@[IPv6:2607:f0d0:1002:51::4]',
+    'valid.ipv6.addr@[IPv6:fe80::230:48ff:fe33:bc33]',
+    'valid.ipv6.addr@[IPv6:fe80:0000:0000:0000:0202:b3ff:fe1e:8329]',
+    'valid.ipv6v4.addr@[IPv6:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:127.0.0.1]',
 
     // examples from wikipedia
-    "niceandsimple@example.com",
-    "very.common@example.com",
-    "a.little.lengthy.but.fine@dept.example.com",
-    "disposable.style.email.with+symbol@example.com",
-    "user@[IPv6:2001:db8:1ff::a0b:dbd0]",
-    "\"much.more unusual\"@example.com",
-    "\"very.unusual.@.unusual.com\"@example.com",
-    "\"very.(),:;<>[]\\\".VERY.\\\"very@\\\\ \\\"very\\\".unusual\"@strange.example.com",
+    'niceandsimple@example.com',
+    'very.common@example.com',
+    'a.little.lengthy.but.fine@dept.example.com',
+    'disposable.style.email.with+symbol@example.com',
+    'user@[IPv6:2001:db8:1ff::a0b:dbd0]',
+    '\"much.more unusual\"@example.com',
+    '\"very.unusual.@.unusual.com\"@example.com',
+    '\"very.(),:;<>[]\\\".VERY.\\\"very@\\\\ \\\"very\\\".unusual\"@strange.example.com',
     "!#\$%&'*+-/=?^_`{}|~@example.org",
     "\"()<>[]:,;@\\\\\\\"!#\$%&'*+-/=?^_`{}| ~.a\"@example.org",
-    "\" \"@example.org",
+    '" "@example.org',
 
     // examples from https://github.com/Sembiance/email-validator
-    "\"\\e\\s\\c\\a\\p\\e\\d\"@sld.com",
-    "\"back\\slash\"@sld.com",
-    "\"escaped\\\"quote\"@sld.com",
-    "\"quoted\"@sld.com",
-    "\"quoted-at-sign@sld.org\"@sld.com",
+    '\"\\e\\s\\c\\a\\p\\e\\d\"@sld.com',
+    '\"back\\slash\"@sld.com',
+    '\"escaped\\\"quote\"@sld.com',
+    '\"quoted\"@sld.com',
+    '\"quoted-at-sign@sld.org\"@sld.com',
     "&'*+-./=?^_{}~@other-valid-characters-in-local.net",
-    "01234567890@numbers-in-local.net",
-    "a@single-character-in-local.org",
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ@letters-in-local.org",
-    "backticksarelegit@test.com",
-    "bracketed-IP-instead-of-domain@[127.0.0.1]",
-    "country-code-tld@sld.rw",
-    "country-code-tld@sld.uk",
-    "letters-in-sld@123.com",
-    "local@dash-in-sld.com",
-    "local@sld.newTLD",
-    "local@sub.domains.com",
-    "mixed-1234-in-{+^}-local@sld.net",
-    "one-character-third-level@a.example.com",
-    "one-letter-sld@x.org",
-    "punycode-numbers-in-tld@sld.xn--3e0b707e",
-    "single-character-in-sld@x.org",
-    "the-character-limit@for-each-part.of-the-domain.is-sixty-three-characters.this-is-exactly-sixty-three-characters-so-it-is-valid-blah-blah.com",
-    "the-total-length@of-an-entire-address.cannot-be-longer-than-two-hundred-and-fifty-four-characters.and-this-address-is-254-characters-exactly.so-it-should-be-valid.and-im-going-to-add-some-more-words-here.to-increase-the-length-blah-blah-blah-blah-bla.org",
-    "uncommon-tld@sld.mobi",
-    "uncommon-tld@sld.museum",
-    "uncommon-tld@sld.travel"
+    '01234567890@numbers-in-local.net',
+    'a@single-character-in-local.org',
+    'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ@letters-in-local.org',
+    'backticksarelegit@test.com',
+    'bracketed-IP-instead-of-domain@[127.0.0.1]',
+    'country-code-tld@sld.rw',
+    'country-code-tld@sld.uk',
+    'letters-in-sld@123.com',
+    'local@dash-in-sld.com',
+    'local@sld.newTLD',
+    'local@sub.domains.com',
+    'mixed-1234-in-{+^}-local@sld.net',
+    'one-character-third-level@a.example.com',
+    'one-letter-sld@x.org',
+    'punycode-numbers-in-tld@sld.xn--3e0b707e',
+    'single-character-in-sld@x.org',
+    'the-character-limit@for-each-part.of-the-domain.is-sixty-three-characters.this-is-exactly-sixty-three-characters-so-it-is-valid-blah-blah.com',
+    'the-total-length@of-an-entire-address.cannot-be-longer-than-two-hundred-and-fifty-four-characters.and-this-address-is-254-characters-exactly.so-it-should-be-valid.and-im-going-to-add-some-more-words-here.to-increase-the-length-blah-blah-blah-blah-bla.org',
+    'uncommon-tld@sld.mobi',
+    'uncommon-tld@sld.museum',
+    'uncommon-tld@sld.travel'
   ];
 
   var invalidAddresses = [
-    "invalid",
-    "invalid@",
-    "invalid @",
-    "invalid@[555.666.777.888]",
-    "invalid@[IPv6:123456]",
-    "invalid@[127.0.0.1.]",
-    "invalid@[127.0.0.1].",
-    "invalid@[127.0.0.1]x",
+    'invalid',
+    'invalid@',
+    'invalid @',
+    'invalid@[555.666.777.888]',
+    'invalid@[IPv6:123456]',
+    'invalid@[127.0.0.1.]',
+    'invalid@[127.0.0.1].',
+    'invalid@[127.0.0.1]x',
 
     // examples from wikipedia
-    "Abc.example.com",
-    "A@b@c@example.com",
-    "a\"b(c)d,e:f;g<h>i[j\\k]l@example.com",
-    "just\"not\"right@example.com",
-    "this is\"not\\allowed@example.com",
-    "this\\ still\\\"not\\\\allowed@example.com",
+    'Abc.example.com',
+    'A@b@c@example.com',
+    'a\"b(c)d,e:f;g<h>i[j\\k]l@example.com',
+    'just\"not\"right@example.com',
+    'this is\"not\\allowed@example.com',
+    'this\\ still\\\"not\\\\allowed@example.com',
 
     // examples from https://github.com/Sembiance/email-validator
-    "! #\$%`|@invalid-characters-in-local.org",
-    "(),:;`|@more-invalid-characters-in-local.org",
-    "* .local-starts-with-dot@sld.com",
-    "<>@[]`|@even-more-invalid-characters-in-local.org",
-    "@missing-local.org",
-    "IP-and-port@127.0.0.1:25",
-    "another-invalid-ip@127.0.0.256",
-    "invalid",
-    "invalid-characters-in-sld@! \"#\$%(),/;<>_[]`|.org",
-    "invalid-ip@127.0.0.1.26",
-    "local-ends-with-dot.@sld.com",
-    "missing-at-sign.net",
-    "missing-sld@.com",
-    "missing-tld@sld.",
-    "sld-ends-with-dash@sld-.com",
-    "sld-starts-with-dashsh@-sld.com",
-    "the-character-limit@for-each-part.of-the-domain.is-sixty-three-characters.this-is-exactly-sixty-four-characters-so-it-is-invalid-blah-blah.com",
-    "the-local-part-is-invalid-if-it-is-longer-than-sixty-four-characters@sld.net",
-    "the-total-length@of-an-entire-address.cannot-be-longer-than-two-hundred-and-fifty-four-characters.and-this-address-is-255-characters-exactly.so-it-should-be-invalid.and-im-going-to-add-some-more-words-here.to-increase-the-lenght-blah-blah-blah-blah-bl.org",
-    "two..consecutive-dots@sld.com",
-    "unbracketed-IP@127.0.0.1",
+    '! #\$%`|@invalid-characters-in-local.org',
+    '(),:;`|@more-invalid-characters-in-local.org',
+    '* .local-starts-with-dot@sld.com',
+    '<>@[]`|@even-more-invalid-characters-in-local.org',
+    '@missing-local.org',
+    'IP-and-port@127.0.0.1:25',
+    'another-invalid-ip@127.0.0.256',
+    'invalid',
+    'invalid-characters-in-sld@! \"#\$%(),/;<>_[]`|.org',
+    'invalid-ip@127.0.0.1.26',
+    'local-ends-with-dot.@sld.com',
+    'missing-at-sign.net',
+    'missing-sld@.com',
+    'missing-tld@sld.',
+    'sld-ends-with-dash@sld-.com',
+    'sld-starts-with-dashsh@-sld.com',
+    'the-character-limit@for-each-part.of-the-domain.is-sixty-three-characters.this-is-exactly-sixty-four-characters-so-it-is-invalid-blah-blah.com',
+    'the-local-part-is-invalid-if-it-is-longer-than-sixty-four-characters@sld.net',
+    'the-total-length@of-an-entire-address.cannot-be-longer-than-two-hundred-and-fifty-four-characters.and-this-address-is-255-characters-exactly.so-it-should-be-invalid.and-im-going-to-add-some-more-words-here.to-increase-the-lenght-blah-blah-blah-blah-bl.org',
+    'two..consecutive-dots@sld.com',
+    'unbracketed-IP@127.0.0.1',
 
     // examples of real (invalid) input from real users.
-    "No longer available.",
-    "Moved.",
+    'No longer available.',
+    'Moved.',
   ];
 
   var validInternational = [
-    "伊昭傑@郵件.商務", // Chinese
-    "राम@मोहन.ईन्फो", // Hindi
-    "юзер@екзампл.ком", // Ukranian
-    "θσερ@εχαμπλε.ψομ", // Greek
+    '伊昭傑@郵件.商務', // Chinese
+    'राम@मोहन.ईन्फो', // Hindi
+    'юзер@екзампл.ком', // Ukranian
+    'θσερ@εχαμπλε.ψομ', // Greek
   ];
 
-  test("Validate that validate throws error on null email", () {
-    expect(() => EmailValidator.Validate(null),
+  test('Validate that validate throws error on null email', () {
+    expect(() => EmailValidator.validate(null),
         throwsA(new isInstanceOf<ArgumentError>()));
   });
 
-  test("Validate invalidAddresses are invalid emails", () {
+  test('Validate invalidAddresses are invalid emails', () {
     invalidAddresses.forEach((actual) => expect(
-        EmailValidator.Validate(actual, true), equals(false),
-        reason: "E-mail: " + actual));
+        EmailValidator.validate(actual, true), equals(false),
+        reason: 'E-mail: ' + actual));
   });
 
-  test("Validate validAddresses are valid emails", () {
+  test('Validate validAddresses are valid emails', () {
     validAddresses.forEach((actual) => expect(
-        EmailValidator.Validate(actual, true), equals(true),
-        reason: "E-mail: " + actual));
+        EmailValidator.validate(actual, true), equals(true),
+        reason: 'E-mail: ' + actual));
   });
 
-    test("Validate validInternational are valid emails", () {
+    test('Validate validInternational are valid emails', () {
     validInternational.forEach((actual) => expect(
-        EmailValidator.Validate(actual, true, true), equals(true),
-        reason: "E-mail: " + actual));
+        EmailValidator.validate(actual, true, true), equals(true),
+        reason: 'E-mail: ' + actual));
   });
 }


### PR DESCRIPTION
Breaking changes in the API. Change `Validate` to `validate` to make the Dart linter happy. This is also a common convention in Dart lang. 